### PR TITLE
chore: update GitHub Actions workflow to make publish job the last step

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
@@ -37,12 +37,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    # Ensure publish waits for build to succeed
+    needs: build
+
     permissions:
       contents: read
       id-token: write
 
     steps:
       - uses: actions/checkout@v4
-
       - name: Publish package
         run: npx jsr publish


### PR DESCRIPTION
Update GitHub Actions workflow to make publish job the last step